### PR TITLE
Merge the localized hash with the default

### DIFF
--- a/lib/jekyll/locale/handler.rb
+++ b/lib/jekyll/locale/handler.rb
@@ -40,8 +40,8 @@ module Jekyll
     end
 
     def data
-      locale_data[snakeified_keys(current_locale)] ||
-        locale_data[snakeified_keys(default_locale)] || {}
+      Hash(locale_data[snakeified_keys(default_locale)])
+        .merge(Hash(locale_data[snakeified_keys(current_locale)]))
     end
 
     def read


### PR DESCRIPTION
This allows for a touch more graceful failover, where the default locale is shown when no translated equivalent exists